### PR TITLE
tableau cloud oauth add

### DIFF
--- a/terraform/snowflake/accounts/main/_oauth_integration_for_partner_applications.tf
+++ b/terraform/snowflake/accounts/main/_oauth_integration_for_partner_applications.tf
@@ -1,0 +1,18 @@
+# ########################
+# # oauth integration for partner applications
+# https://docs.snowflake.com/ja/sql-reference/sql/create-security-integration-oauth-snowflake
+# https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/oauth_integration_for_partner_applications
+# ########################
+
+# tableau cloud oauth
+module "account_oauth_integration_for_partner_applications" {
+  source = "../../modules/oauth_integration_for_partner_applications"
+  providers = {
+    snowflake = snowflake.fr_security_manager
+  }
+
+  name         = "TABLEAU_CLOUD_SECURITY_INTEGRATION"
+  oauth_client = "TABLEAU_SERVER"
+  comment      = "for tableau cloud oauth"
+
+}

--- a/terraform/snowflake/modules/oauth_integration_for_partner_applications/main.tf
+++ b/terraform/snowflake/modules/oauth_integration_for_partner_applications/main.tf
@@ -1,0 +1,12 @@
+# https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/oauth_integration_for_partner_applications
+# snowflake_oauth_integration_for_partner_applications
+resource "snowflake_oauth_integration_for_partner_applications" "this" {
+  name                         = var.name
+  oauth_client                 = var.oauth_client
+  enabled                      = var.enabled
+  oauth_issue_refresh_tokens   = var.oauth_issue_refresh_tokens
+  oauth_refresh_token_validity = var.oauth_refresh_token_validity
+  oauth_use_secondary_roles    = var.oauth_use_secondary_roles
+  blocked_roles_list           = var.blocked_roles_list
+  comment                      = var.comment
+}

--- a/terraform/snowflake/modules/oauth_integration_for_partner_applications/outputs.tf
+++ b/terraform/snowflake/modules/oauth_integration_for_partner_applications/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "Name of the OAuth integration."
+  value       = snowflake_oauth_integration_for_partner_applications.this.name
+}

--- a/terraform/snowflake/modules/oauth_integration_for_partner_applications/variables.tf
+++ b/terraform/snowflake/modules/oauth_integration_for_partner_applications/variables.tf
@@ -1,0 +1,45 @@
+variable "name" {
+  description = "The name of the oauth integration for partner applications"
+  type        = string
+}
+
+variable "oauth_client" {
+  description = "The oauth client to use for the oauth integration for partner applications"
+  type        = string
+}
+
+variable "enabled" {
+  description = "Whether the oauth integration for partner applications is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "oauth_issue_refresh_tokens" {
+  description = "Whether the oauth integration for partner applications issues refresh tokens"
+  type        = bool
+  default     = true
+}
+
+variable "oauth_refresh_token_validity" {
+  description = "The validity of the oauth refresh token"
+  type        = number
+  default     = 432000 # 5日
+}
+
+variable "oauth_use_secondary_roles" {
+  description = "The secondary roles to use for the oauth integration for partner applications"
+  type        = string
+  default     = "NONE"
+}
+
+variable "blocked_roles_list" {
+  description = "The roles to block for the oauth integration for partner applications"
+  type        = list(string)
+  default     = []
+}
+
+variable "comment" {
+  description = "The comment for the oauth integration for partner applications"
+  type        = string
+  default     = null
+}

--- a/terraform/snowflake/modules/oauth_integration_for_partner_applications/versions.tf
+++ b/terraform/snowflake/modules/oauth_integration_for_partner_applications/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "~> 2.1.0"
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Snowflakeでパートナーアプリケーション向けのOAuth統合を管理するTerraformモジュールを追加しました。
  * Tableau Cloud用のOAuth統合設定が利用可能になりました。
  * 統合名や有効/無効設定、リフレッシュトークンの発行や有効期間、ブロックするロールの指定など柔軟な設定が可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->