### PR TITLE
SR_TABLEAUに全てのオブジェクトで読み取り権限を付与

### DIFF
--- a/terraform/snowflake/accounts/main/_db_data_lake.tf
+++ b/terraform/snowflake/accounts/main/_db_data_lake.tf
@@ -137,7 +137,8 @@ module "data_lake_db_service_b_schema" {
   read_only_ar_to_fr_set = [
     module.fr_data_engineer.name,
     module.fr_analyst.name,
-    module.fr_scientist.name
+    module.fr_scientist.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [

--- a/terraform/snowflake/accounts/main/_db_dwh.tf
+++ b/terraform/snowflake/accounts/main/_db_dwh.tf
@@ -21,7 +21,8 @@ module "dwh_db" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
   sr_import_ar_to_fr_set = [
     module.sr_trocco_import.name
@@ -56,7 +57,8 @@ module "dwh_db_service_AB_schema" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [

--- a/terraform/snowflake/accounts/main/_db_mart.tf
+++ b/terraform/snowflake/accounts/main/_db_mart.tf
@@ -21,7 +21,8 @@ module "mart_db" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [
@@ -57,7 +58,8 @@ module "mart_db_tableau_schema" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [
@@ -90,7 +92,8 @@ module "mart_db_ad_google_schema" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [

--- a/terraform/snowflake/accounts/main/_db_spreadsheet.tf
+++ b/terraform/snowflake/accounts/main/_db_spreadsheet.tf
@@ -11,6 +11,10 @@ module "spreadsheet_db" {
   comment                     = "Database to store and process Google Spreadsheet data from TROCCO"
   data_retention_time_in_days = 1
 
+  read_only_ar_to_fr_set = [
+    module.sr_tableau.name
+  ]
+
   sr_import_ar_to_fr_set = [
     module.sr_trocco_spreadsheet.name
   ]
@@ -33,6 +37,10 @@ module "spreadsheet_db_lake_schema" {
   database_name               = module.spreadsheet_db.name
   comment                     = "Schema to store raw Google Spreadsheet data from TROCCO"
   data_retention_time_in_days = 1
+
+  read_only_ar_to_fr_set = [
+    module.sr_tableau.name
+  ]
 
   sr_import_ar_to_fr_set = [
     module.sr_trocco_spreadsheet.name
@@ -57,6 +65,10 @@ module "spreadsheet_db_staging_schema" {
   comment                     = "Schema to store cleaned Google Spreadsheet data"
   data_retention_time_in_days = 1
 
+  read_only_ar_to_fr_set = [
+    module.sr_tableau.name
+  ]
+
   sr_import_ar_to_fr_set = [
     module.sr_trocco_spreadsheet.name
   ]
@@ -80,6 +92,10 @@ module "spreadsheet_db_dwh_schema" {
   comment                     = "Schema to store data warehouse tables from Google Spreadsheets"
   data_retention_time_in_days = 1
 
+  read_only_ar_to_fr_set = [
+    module.sr_tableau.name
+  ]
+
   sr_import_ar_to_fr_set = [
     module.sr_trocco_spreadsheet.name
   ]
@@ -102,6 +118,10 @@ module "spreadsheet_db_mart_schema" {
   database_name               = module.spreadsheet_db.name
   comment                     = "Schema to store analysis-ready data from Google Spreadsheets"
   data_retention_time_in_days = 1
+
+  read_only_ar_to_fr_set = [
+    module.sr_tableau.name
+  ]
 
   sr_import_ar_to_fr_set = [
     module.sr_trocco_spreadsheet.name

--- a/terraform/snowflake/accounts/main/_db_staging.tf
+++ b/terraform/snowflake/accounts/main/_db_staging.tf
@@ -21,7 +21,8 @@ module "staging_db" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [
@@ -57,7 +58,8 @@ module "staging_db_service_a_schema" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [
@@ -90,7 +92,8 @@ module "staging_db_service_b_schema" {
   ]
 
   read_only_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [

--- a/terraform/snowflake/accounts/main/_db_workspace.tf
+++ b/terraform/snowflake/accounts/main/_db_workspace.tf
@@ -23,7 +23,8 @@ module "workspace_db" {
   read_only_ar_to_fr_set = [
     module.fr_data_engineer.name,
     module.fr_scientist.name,
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [
@@ -58,7 +59,8 @@ module "workspace_db_service_a_schema" {
   read_only_ar_to_fr_set = [
     module.fr_data_engineer.name,
     module.fr_scientist.name,
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
 
   sr_import_ar_to_fr_set = [

--- a/terraform/snowflake/accounts/main/locals.tf
+++ b/terraform/snowflake/accounts/main/locals.tf
@@ -10,4 +10,10 @@ locals {
     "LEE@THINKER-INC.JP"
   ]
 
+  # 新規追加ユーザー
+  new_users = [
+    "SAKAMUNE@THINKER-INC.JP",
+    "MIYAHARA@THINKER-INC.JP"
+  ]
+
 }

--- a/terraform/snowflake/accounts/main/locals.tf
+++ b/terraform/snowflake/accounts/main/locals.tf
@@ -10,8 +10,8 @@ locals {
     "LEE@THINKER-INC.JP"
   ]
 
-  # 新規追加ユーザー
-  new_users = [
+  # 分析利用者
+  analytics_users = [
     "SAKAMUNE@THINKER-INC.JP",
     "MIYAHARA@THINKER-INC.JP"
   ]

--- a/terraform/snowflake/accounts/main/main.tf
+++ b/terraform/snowflake/accounts/main/main.tf
@@ -35,7 +35,7 @@ module "fr_data_engineer" {
   }
 
   role_name      = "FR_DATA_ENGINEER"
-  grant_user_set = local.manager
+  grant_user_set = concat(local.manager, local.new_users)
   comment        = "Functional Role for Data Engineer in Project all"
 }
 
@@ -68,7 +68,7 @@ module "sr_tableau" {
   }
 
   role_name      = "SR_TABLEAU"
-  grant_user_set = local.manager
+  grant_user_set = concat(local.manager, local.new_users)
   comment        = "Functional Role for business intelligence in Project {}"
 }
 
@@ -81,7 +81,7 @@ module "sr_trocco_import" {
 
   role_name = "SR_TROCCO_IMPORT"
 
-  grant_user_set = concat(local.manager, ["TROCCO_USER"])
+  grant_user_set = concat(local.manager, local.new_users, ["TROCCO_USER"])
   comment        = "Functional Role for trocco import in Project {}"
 }
 

--- a/terraform/snowflake/accounts/main/main.tf
+++ b/terraform/snowflake/accounts/main/main.tf
@@ -35,7 +35,7 @@ module "fr_data_engineer" {
   }
 
   role_name      = "FR_DATA_ENGINEER"
-  grant_user_set = concat(local.manager, local.new_users)
+  grant_user_set = concat(local.manager, local.analytics_users)
   comment        = "Functional Role for Data Engineer in Project all"
 }
 
@@ -68,7 +68,7 @@ module "sr_tableau" {
   }
 
   role_name      = "SR_TABLEAU"
-  grant_user_set = concat(local.manager, local.new_users)
+  grant_user_set = concat(local.manager, local.analytics_users)
   comment        = "Functional Role for business intelligence in Project {}"
 }
 
@@ -81,7 +81,7 @@ module "sr_trocco_import" {
 
   role_name = "SR_TROCCO_IMPORT"
 
-  grant_user_set = concat(local.manager, local.new_users, ["TROCCO_USER"])
+  grant_user_set = concat(local.manager, local.analytics_users, ["TROCCO_USER"])
   comment        = "Functional Role for trocco import in Project {}"
 }
 

--- a/terraform/snowflake/accounts/main/main.tf
+++ b/terraform/snowflake/accounts/main/main.tf
@@ -159,7 +159,8 @@ module "read_only_wh" {
   comment        = "Warehouse for Read Only of {} projects"
 
   grant_usage_ar_to_fr_set = [
-    module.fr_analyst.name
+    module.fr_analyst.name,
+    module.sr_tableau.name
   ]
   grant_admin_ar_to_fr_set = [
     module.fr_manager.name


### PR DESCRIPTION
# 新規ユーザー追加とSR_TABLEAUロール権限拡張

## 概要

### 1. SR_TABLEAUロールの権限拡張

#### データベースレベル
以下のデータベースの `read_only_ar_to_fr_set` に `SR_TABLEAU` を追加：

- **DWH** (`_db_dwh.tf`)
- **MART** (`_db_mart.tf`)
- **STAGING** (`_db_staging.tf`)
- **WORKSPACE** (`_db_workspace.tf`)
- **SPREADSHEET_DATA** (`_db_spreadsheet.tf`)

#### スキーマレベル
以下のスキーマの `read_only_ar_to_fr_set` に `SR_TABLEAU` を追加：

- **DATA_LAKE.SERVICE_B** (`_db_data_lake.tf`)
- **DWH.DATAMODEL_AB** (`_db_dwh.tf`)
- **MART.TABLEAU_BI** (`_db_mart.tf`)
- **MART.AD_GOOGLE** (`_db_mart.tf`)
- **STAGING.SERVICE_A** (`_db_staging.tf`)
- **STAGING.SERVICE_B** (`_db_staging.tf`)
- **WORKSPACE.SPOT** (`_db_workspace.tf`)
- **SPREADSHEET_DATA.LAKE** (`_db_spreadsheet.tf`)
- **SPREADSHEET_DATA.STAGING** (`_db_spreadsheet.tf`)
- **SPREADSHEET_DATA.DWH** (`_db_spreadsheet.tf`)
- **SPREADSHEET_DATA.MART** (`_db_spreadsheet.tf`)

#### ウェアハウスレベル
- **READ_ONLY_WH** の `grant_usage_ar_to_fr_set` に `SR_TABLEAU` を追加

#### `SR_TABLEAU`ロール
- **全データベース**: 読み取り専用権限
- **全スキーマ**: 読み取り専用権限
- **ウェアハウス**: `SR_TABLEAU_WH`、`READ_ONLY_WH`へのアクセス権限

#### Troccoロール
- **SR_TROCCO_IMPORT**: データインポート権限
- **SR_TROCCO_TRANSFORM**: データ変換権限
- **SR_TROCCO_SPREADSHEET**: スプレッドシート処理権限

## 影響範囲

### データベース
- ✅ **DATA_LAKE**: SR_TABLEAUアクセス可能
- ✅ **DWH**: SR_TABLEAUアクセス可能
- ✅ **MART**: SR_TABLEAUアクセス可能
- ✅ **STAGING**: SR_TABLEAUアクセス可能
- ✅ **WORKSPACE**: SR_TABLEAUアクセス可能
- ✅ **SPREADSHEET_DATA**: SR_TABLEAUアクセス可能

### スキーマ
- ✅ **DATA_LAKE.SERVICE_A**: SR_TABLEAUアクセス可能
- ✅ **DATA_LAKE.SERVICE_B**: SR_TABLEAUアクセス可能
- ✅ **DWH.DATAMODEL_AB**: SR_TABLEAUアクセス可能
- ✅ **MART.TABLEAU_BI**: SR_TABLEAUアクセス可能
- ✅ **MART.AD_GOOGLE**: SR_TABLEAUアクセス可能
- ✅ **STAGING.SERVICE_A**: SR_TABLEAUアクセス可能
- ✅ **STAGING.SERVICE_B**: SR_TABLEAUアクセス可能
- ✅ **WORKSPACE.SPOT**: SR_TABLEAUアクセス可能
- ✅ **SPREADSHEET_DATA.LAKE**: SR_TABLEAUアクセス可能
- ✅ **SPREADSHEET_DATA.STAGING**: SR_TABLEAUアクセス可能
- ✅ **SPREADSHEET_DATA.DWH**: SR_TABLEAUアクセス可能
- ✅ **SPREADSHEET_DATA.MART**: SR_TABLEAUアクセス可能

## セキュリティ考慮事項

- `SR_TABLEAU`ロールは読み取り専用権限のみ付与
- Tableauでの参照は`SR_TABLEAU`ロールでのみ可能

## テスト項目

- [ ] 新規ユーザーが`SR_TABLEAU`ロールでTableauからデータ参照可能であること
- [ ] `SR_TABLEAU`ロールが全てのデータベース・スキーマにアクセス可能であること

## 関連Issue

- Tableauでの全データアクセス要求

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 複数のデータベースおよびスキーマで「sr_tableau」ロールに読み取り専用アクセス権限を追加しました。
  * 読み取り専用ウェアハウスで「sr_tableau」ロールに利用権限を追加しました。
  * 「fr_data_engineer」「sr_tableau」「sr_trocco_import」ロールに新規ユーザーを付与しました。
  * 新たに「analytics_users」ユーザーグループを追加し、関連ロールに割り当てました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->