### PR TITLE
tableau デスクトップにキーペア認証でも可能にする

### DIFF
--- a/terraform/snowflake/accounts/main/_authentication_policy.tf
+++ b/terraform/snowflake/accounts/main/_authentication_policy.tf
@@ -22,7 +22,7 @@ module "account_authentication_policy" {
   mfa_enrollment             = "REQUIRED"
 }
 
-# 開発者用ポリシー（API/ドライバーアクセス用 - キーペア認証）
+# 開発者用ポリシー（API/ドライバーアクセス用 - キーペア認証、パスワード認証、OAuth認証対応）
 module "developer_authentication_policy" {
   depends_on = [module.security_db_authentication_schema]
   source     = "../../modules/authentication_policy"
@@ -38,7 +38,7 @@ module "developer_authentication_policy" {
   client_types               = ["ALL"]
   mfa_authentication_methods = ["PASSWORD"]
   mfa_enrollment             = "REQUIRED"
-  users                      = local.manager
+  users                      = concat(local.manager, local.analytics_users)
 }
 
 # TROCCO用ポリシー
@@ -60,20 +60,4 @@ module "trocco_authentication_policy" {
   ]
 }
 
-# Tableau用ポリシー（OAuth認証）
-module "tableau_authentication_policy" {
-  depends_on = [module.security_db_authentication_schema, module.tableau_cloud_oauth_integration, module.tableau_desktop_oauth_integration]
-  source     = "../../modules/authentication_policy"
-  providers = {
-    snowflake = snowflake.fr_security_manager
-  }
 
-  database = module.security_db.name
-  schema   = module.security_db_authentication_schema.name
-  name     = "TABLEAU_OAUTH_AUTHENTICATION_POLICY"
-
-  authentication_methods = ["OAUTH"]
-  client_types           = ["DRIVERS"]
-  mfa_enrollment         = "OPTIONAL"
-  users                  = [] # TableauはOAuthでログインするので、Snowflake側で個別のユーザーを指定する必要がない
-}

--- a/terraform/snowflake/accounts/main/main.tf
+++ b/terraform/snowflake/accounts/main/main.tf
@@ -57,7 +57,7 @@ module "fr_analyst" {
   }
 
   role_name      = "FR_ANALYST"
-  grant_user_set = local.manager
+  grant_user_set = concat(local.manager, local.analytics_users)
   comment        = "Functional Role for analysis in Project {}"
 }
 

--- a/terraform/snowflake/accounts/main/security.tf
+++ b/terraform/snowflake/accounts/main/security.tf
@@ -146,6 +146,6 @@ module "network_policy_tableau" {
   blocked_network_rule_list = []
 
   set_for_account = false
-  users           = local.manager
+  users           = concat(local.manager, local.analytics_users)
 }
 


### PR DESCRIPTION
・developer_authentication_policyモジュールのusersパラメータを変更
・local.managerのみから、local.managerとlocal.analytics_usersの両方を含むように修正
・concat()関数を使用して2つのリストを結合
・Analystユーザー（SAKAMUNE@THINKER-INC.JP, MIYAHARA@THINKER-INC.JP）がDEVELOPER_AUTHENTICATION_USER_POLICYに含まれるようになった
・キーペア認証とTableauアクセスがAnalystユーザーにも適用されるようになった
・fr_analystにanalystを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - アナリティクスユーザーを開発者向け認証ポリシーの対象に追加
  - アナリティクスユーザーを FR_ANALYST の対象ユーザーに追加
  - アナリティクスユーザーを Tableau 関連ネットワークポリシーの対象に追加
- 雑務
  - Tableau 向け OAuth 認証ポリシーを削除

<!-- end of auto-generated comment: release notes by coderabbit.ai -->