### PR TITLE
Snowflake Provider v2.14.1 更新と田村さんユーザー追加

### DIFF
--- a/terraform/snowflake/accounts/main/_authentication_policy.tf
+++ b/terraform/snowflake/accounts/main/_authentication_policy.tf
@@ -16,10 +16,9 @@ module "account_authentication_policy" {
   schema     = module.security_db_authentication_schema.name
   name       = "REQUIRE_MFA_AUTHENTICATION_ACCOUNT_POLICY"
 
-  authentication_methods     = ["PASSWORD"]
-  client_types               = ["SNOWFLAKE_UI"]
-  mfa_authentication_methods = ["PASSWORD"]
-  mfa_enrollment             = "REQUIRED"
+  authentication_methods = ["PASSWORD"]
+  client_types           = ["SNOWFLAKE_UI"]
+  mfa_enrollment         = "REQUIRED"
 }
 
 # 開発者用ポリシー（API/ドライバーアクセス用 - キーペア認証、パスワード認証、OAuth認証対応）
@@ -34,11 +33,10 @@ module "developer_authentication_policy" {
   schema   = module.security_db_authentication_schema.name
   name     = "DEVELOPER_AUTHENTICATION_USER_POLICY"
 
-  authentication_methods     = ["ALL"]
-  client_types               = ["ALL"]
-  mfa_authentication_methods = ["PASSWORD"]
-  mfa_enrollment             = "REQUIRED"
-  users                      = concat(local.manager, local.analytics_users)
+  authentication_methods = ["ALL"]
+  client_types           = ["ALL"]
+  mfa_enrollment         = "REQUIRED"
+  users                  = concat(local.manager, local.analytics_users)
 }
 
 # TROCCO用ポリシー

--- a/terraform/snowflake/accounts/main/locals.tf
+++ b/terraform/snowflake/accounts/main/locals.tf
@@ -13,7 +13,8 @@ locals {
   # 分析利用者
   analytics_users = [
     "SAKAMUNE@THINKER-INC.JP",
-    "MIYAHARA@THINKER-INC.JP"
+    "MIYAHARA@THINKER-INC.JP",
+    "H.TAMURA@THINKER-INC.JP"
   ]
 
 }

--- a/terraform/snowflake/accounts/main/versions.tf
+++ b/terraform/snowflake/accounts/main/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }
@@ -33,7 +33,6 @@ provider "snowflake" {
   alias = "fr_security_manager"
   role  = "FR_SECURITY_MANAGER"
   preview_features_enabled = [
-    "snowflake_network_rule_resource",
     "snowflake_network_policy_attachment_resource",
     "snowflake_password_policy_resource",
     "snowflake_account_password_policy_attachment_resource",

--- a/terraform/snowflake/modules/access_role_and_database/versions.tf
+++ b/terraform/snowflake/modules/access_role_and_database/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/access_role_and_schema/versions.tf
+++ b/terraform/snowflake/modules/access_role_and_schema/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/access_role_and_warehouse/versions.tf
+++ b/terraform/snowflake/modules/access_role_and_warehouse/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/authentication_policy/main.tf
+++ b/terraform/snowflake/modules/authentication_policy/main.tf
@@ -5,7 +5,6 @@ resource "snowflake_authentication_policy" "this" {
   schema                     = var.schema
   name                       = upper(var.name)
   authentication_methods     = var.authentication_methods
-  mfa_authentication_methods = var.mfa_authentication_methods
   mfa_enrollment             = var.mfa_enrollment
   client_types               = var.client_types
   security_integrations      = var.security_integrations

--- a/terraform/snowflake/modules/authentication_policy/variables.tf
+++ b/terraform/snowflake/modules/authentication_policy/variables.tf
@@ -19,12 +19,6 @@ variable "authentication_methods" {
   default     = ["ALL"]
 }
 
-variable "mfa_authentication_methods" {
-  description = "List of MFA authentication methods. { ALL | SAML | PASSWORD }"
-  type        = list(string)
-  default     = null
-}
-
 variable "mfa_enrollment" {
   description = "MFA enrollment setting. { OPTIONAL | REQUIRED }"
   type        = string

--- a/terraform/snowflake/modules/authentication_policy/versions.tf
+++ b/terraform/snowflake/modules/authentication_policy/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/file_format/versions.tf
+++ b/terraform/snowflake/modules/file_format/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/functional_role/versions.tf
+++ b/terraform/snowflake/modules/functional_role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/network_policy/versions.tf
+++ b/terraform/snowflake/modules/network_policy/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/network_rule/versions.tf
+++ b/terraform/snowflake/modules/network_rule/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/oauth_integration_for_partner_applications/versions.tf
+++ b/terraform/snowflake/modules/oauth_integration_for_partner_applications/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/password_policy/versions.tf
+++ b/terraform/snowflake/modules/password_policy/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/service_user/versions.tf
+++ b/terraform/snowflake/modules/service_user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/stage/versions.tf
+++ b/terraform/snowflake/modules/stage/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }

--- a/terraform/snowflake/modules/storage_integration/versions.tf
+++ b/terraform/snowflake/modules/storage_integration/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflakedb/snowflake"
-      version = "~> 2.1.0"
+      version = "~> 2.14.1"
     }
   }
 }


### PR DESCRIPTION
# Snowflake Provider v2.14.1 更新の背景と差分整理

## 概要

今回の変更では、`snowflakedb/snowflake` provider を `~> 2.1.0` から `~> 2.14.1` へ更新し、`authentication_policy` 周辺で発生していた不要差分と warning を解消した。

あわせて、`v2.14.1` の migration guide に従い、`mfa_authentication_methods` を Terraform 設定から削除した。

結果として、`terraform plan` で表示される差分は、今回追加した `H.TAMURA@THINKER-INC.JP` に必要な変更だけへ収束した。

## provider 更新前に発生していた差分

provider 更新前は、`H.TAMURA@THINKER-INC.JP` の追加に必要な差分に加えて、`authentication_policy` 本体の不要な差分が混ざっていた。

### full plan で出ていた主な不要差分

- `module.account_authentication_policy.snowflake_authentication_policy.this`
  - `mfa_authentication_methods = ["PASSWORD"]` の update
- `module.developer_authentication_policy.snowflake_authentication_policy.this`
  - `mfa_authentication_methods = ["PASSWORD"]` の update
- `module.looker_studio_authentication_policy.snowflake_authentication_policy.this`
  - `mfa_enrollment` が `REQUIRED_SNOWFLAKE_UI_PASSWORD_ONLY -> OPTIONAL` に見える update
- `module.trocco_authentication_policy.snowflake_authentication_policy.this`
  - `mfa_enrollment` が `REQUIRED_SNOWFLAKE_UI_PASSWORD_ONLY -> OPTIONAL` に見える update

この時点では、ユーザー追加差分以外の `authentication_policy` 差分まで plan に混ざっており、そのまま apply するには安全性の判断が難しい状態だった。

### targeted plan でも残っていた不要差分

`H.TAMURA@THINKER-INC.JP` に関係する resource のみに `-target` で絞っても、以下の差分が残っていた。

- `module.developer_authentication_policy.snowflake_authentication_policy.this`
  - `mfa_authentication_methods = ["PASSWORD"]`

このため、provider 更新前の targeted plan は次の状態だった。

- `Plan: 6 to add, 2 to change, 0 to destroy`
- 追加 6 件は想定どおり
- 変更 2 件のうち 1 件は不要な `authentication_policy` 本体差分

## なぜ不要差分が出ていたか

原因は、Snowflake 側の `DESC AUTHENTICATION POLICY` 出力変更と、古い provider の追随不足にある。

`v2.14.1` の migration guide では、認証ポリシーについて以下が案内されている。

- Snowflake の出力変更により `MFA_AUTHENTICATION_METHODS` の行が返らなくなった
- `mfa_authentication_methods` は provider の `Read` で state に復元されない
- `mfa_authentication_methods` は top-level 属性としては残っていても、設定変更は効果を持たない
- `mfa_authentication_methods` の参照は削除することが推奨されている

参照:

- [Migration guide v2.14.1](https://github.com/snowflakedb/terraform-provider-snowflake/blob/release_v2.14.1/MIGRATION_GUIDE.md#breaking-change-adjustments-in-snowflake_authentication_policy-and-snowflake_authentication_policies-due-to-desc-authentication-policy-output-change)
- [Raw migration guide v2.14.1](https://raw.githubusercontent.com/snowflakedb/terraform-provider-snowflake/release_v2.14.1/MIGRATION_GUIDE.md)

つまり、旧 provider では `authentication_policy` の現在値を安定して読み取れず、Terraform 上で不要差分として見えていた。

## 実施した対応

### 1. provider を v2.14.1 に更新

`accounts/main` だけでなく、各 module の `versions.tf` も含めて `~> 2.14.1` に統一した。

更新対象の代表例:

- `terraform/snowflake/accounts/main/versions.tf`
- `terraform/snowflake/modules/authentication_policy/versions.tf`
- `terraform/snowflake/modules/access_role_and_database/versions.tf`
- `terraform/snowflake/modules/access_role_and_schema/versions.tf`
- `terraform/snowflake/modules/access_role_and_warehouse/versions.tf`

その後、`terraform init -upgrade` を実行して lock file も更新した。

### 2. `mfa_authentication_methods` を Terraform 設定から削除

`v2.14.1` ではこの属性が deprecated かつ no-op になっているため、module の公開インターフェースからも削除した。

修正箇所:

- `terraform/snowflake/modules/authentication_policy/main.tf`
  - `mfa_authentication_methods = var.mfa_authentication_methods` を削除
- `terraform/snowflake/modules/authentication_policy/variables.tf`
  - `variable "mfa_authentication_methods"` を削除
- `terraform/snowflake/accounts/main/_authentication_policy.tf`
  - `account_authentication_policy` と `developer_authentication_policy` 呼び出し時の `mfa_authentication_methods = ["PASSWORD"]` を削除

### 3. auth policy の state を refresh-only で再整備

provider 更新直後は、旧 state に `mfa_authentication_methods` が残っていたため、state decode warning が出た。

そのため、以下の auth policy resource に対して `terraform apply -refresh-only` を実施し、`v2.14.1` の schema に合わせて state を更新した。

- `module.account_authentication_policy.snowflake_authentication_policy.this`
- `module.developer_authentication_policy.snowflake_authentication_policy.this`
- `module.trocco_authentication_policy.snowflake_authentication_policy.this`
- `module.looker_studio_authentication_policy.snowflake_authentication_policy.this`

### 4. stable 化済み preview feature 指定を削除

provider 更新後、`snowflake_network_rule_resource` がすでに stable である warning が出たため、`preview_features_enabled` から削除した。

対象:

- `terraform/snowflake/accounts/main/versions.tf`

## 更新後に出ていた warning と、その解消内容

### warning 1: `unsupported attribute "mfa_authentication_methods"`

#### 発生内容

provider 更新直後の plan では、旧 state の decode 時に以下の warning が出た。

- `module.looker_studio_authentication_policy.snowflake_authentication_policy.this`
- `module.account_authentication_policy.snowflake_authentication_policy.this`
- `module.trocco_authentication_policy.snowflake_authentication_policy.this`

内容:

- `Failed to decode resource from state`
- `unsupported attribute "mfa_authentication_methods"`

#### 発生理由

旧 provider で state に保存されていた `mfa_authentication_methods` を、`v2.14.1` 側が従来通りに解釈できなくなったため。

#### 解消方法

- `mfa_authentication_methods` を config から削除
- 対象 auth policy に対して `terraform apply -refresh-only` を実行

#### 解消結果

- state が新 provider schema に合わせて更新され、warning は消えた

### warning 2: `mfa_authentication_methods` は deprecated で no effect

#### 発生内容

provider 更新直後の plan では、`../../modules/authentication_policy/main.tf` 内の
`mfa_authentication_methods = var.mfa_authentication_methods` に対して deprecated warning が出た。

内容:

- `This field is deprecated and will be removed in the future.`
- `Currently, it has no effect.`

#### 発生理由

`v2.14.1` の仕様上、この属性は今後の管理対象として意味を持たないため。

#### 解消方法

- module の resource 定義から属性を削除
- `variables.tf` から variable 定義を削除
- 呼び出し側からも入力を削除

#### 解消結果

- deprecation warning は消えた

### warning 3: `snowflake_network_rule_resource` は stable

#### 発生内容

provider 更新直後の plan では、`preview_features_enabled` に stable 化済み feature が入っている warning が出た。

内容:

- `Stable feature used on preview feature list`
- `Preview feature snowflake_network_rule_resource was already promoted to stable feature`

#### 発生理由

新 provider では `snowflake_network_rule_resource` が stable 化されており、preview 指定が不要になったため。

#### 解消方法

- `terraform/snowflake/accounts/main/versions.tf` の `preview_features_enabled` から `snowflake_network_rule_resource` を削除

#### 解消結果

- warning は消えた

## provider 更新後に消えた差分

provider 更新前の targeted plan では、`H.TAMURA@THINKER-INC.JP` 追加とは無関係な以下の差分が残っていた。

- `module.developer_authentication_policy.snowflake_authentication_policy.this`
  - `mfa_authentication_methods` に関する update

provider 更新後はこの差分が消え、targeted plan でも通常 plan でも `authentication_policy` 本体の不要差分は出なくなった。

## 最終的に残った差分

最終的な通常 `terraform plan` は warning なしで次の差分だけになった。

- `Plan: 6 to add, 1 to change, 0 to destroy`

内訳:

- `module.developer_authentication_policy.snowflake_user_authentication_policy_attachment.users["H.TAMURA@THINKER-INC.JP"]`
- `module.fr_analyst.snowflake_grant_account_role.grant_to_user["H.TAMURA@THINKER-INC.JP"]`
- `module.fr_data_engineer.snowflake_grant_account_role.grant_to_user["H.TAMURA@THINKER-INC.JP"]`
- `module.fr_scientist.snowflake_grant_account_role.grant_to_user["H.TAMURA@THINKER-INC.JP"]`
- `module.sr_tableau.snowflake_grant_account_role.grant_to_user["H.TAMURA@THINKER-INC.JP"]`
- `module.sr_trocco_import.snowflake_grant_account_role.grant_to_user["H.TAMURA@THINKER-INC.JP"]`
- `module.network_policy_tableau.snowflake_network_policy_attachment.attach`

## 結論

provider 更新前は、`authentication_policy` 周辺の provider 由来の不要差分と warning により、今回のユーザー追加差分だけを安全に判断しづらい状態だった。

`snowflakedb/snowflake v2.14.1` への更新、および `mfa_authentication_methods` の削除と state refresh を行ったことで、以下を達成できた。

- `authentication_policy` 本体の不要差分を解消
- `mfa_authentication_methods` に関する decode / deprecation warning を解消
- stable 化済み preview feature warning を解消
- 最終的な差分を `H.TAMURA@THINKER-INC.JP` 追加に必要な変更のみに限定

その結果、現在の `terraform plan` は、今回のユーザー追加作業として妥当な内容だけを表示する状態になっている。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Snowflake Terraform プロバイダーを複数のモジュール全体で 2.1.0 から 2.14.1 に更新しました。
  * 認証ポリシー設定の MFA 認証方法の明示的な構成を削除しました。
  * 分析ユーザー一覧に新しいユーザーを追加しました。
  * プロバイダー設定から未使用のプレビュー機能フラグを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->